### PR TITLE
#89 fix user testcode

### DIFF
--- a/dorandoran/tests/users/base.py
+++ b/dorandoran/tests/users/base.py
@@ -7,22 +7,22 @@ class BaseUserAPITest:
         self.client = Client()
         self.prepare_fixture()
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def prepare_fixture(self):
         pass
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def test_create_user_success(self):
         pass
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def test_retrieve_user_success(self):
         pass
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def test_list_user_success(self):
         pass
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def test_delete_user_success(self):
         pass


### PR DESCRIPTION
closes #89 
- `BaseUserAPITest`클래스의 메소드 데코레이터로 사용된 `@abc.abstractclassmethod`를 `@abc.abstractmethod`로 변경
- classmethod 용도로 사용되지 않을 뿐만아니라 python 3.3 이후 `@abc.abstractclassmethod`는 `@classmethod`로 대체 하기를 권유함